### PR TITLE
Make cluster `name` attribute optional

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -155,7 +155,7 @@ async def catch_all(path_name: str):
 
 class Cluster(BaseModel):
     uuid: str
-    name: str
+    name: Optional[str]
     managed: Optional[bool] = False
 
 


### PR DESCRIPTION
The `name` attribute is missing in some environments, so it should not be mandatory.