### PR TITLE
Expose mock services publicly

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -14,11 +14,9 @@ objects:
           minReplicas: 1
           webServices:
             public:
-              enabled: false
-            private:
               enabled: true
-            metrics:
-              enabled: false
+              apiPaths:
+                - /api/mock-ams/
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             livenessProbe:

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -16,9 +16,13 @@ objects:
             public:
               enabled: true
               apiPaths:
-                - /api/mock-ams/
+                - "${ROUTE_PREFIX}/"
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
+            command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--log-config=logging.yaml"]
+            env:
+              - name: SERVER_ROUTE_PREFIX
+                value: "${ROUTE_PREFIX}"
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -78,3 +82,8 @@ parameters:
   value: '250Mi'
 - name: MEMORY_LIMIT
   value: '400Mi'
+- description: Path in the route to server requests from
+  name: ROUTE_PREFIX
+  required: true
+  value: "/api/mock-ams"
+  regex: '^\/api\/[a-zA-Z0-9-]+'  # Same regex as clowder without the final /

--- a/deploy/rhobs-mock.yaml
+++ b/deploy/rhobs-mock.yaml
@@ -16,10 +16,13 @@ objects:
             public:
               enabled: true
               apiPaths:
-                - /api/mock-rhobs/
+                - "${ROUTE_PREFIX}/"
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             command: ["uvicorn", "rhobs:app", "--host", "0.0.0.0", "--port", "8000", "--log-config=logging.yaml"]
+            env:
+              - name: SERVER_ROUTE_PREFIX
+                value: "${ROUTE_PREFIX}"
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -79,3 +82,8 @@ parameters:
   value: '250Mi'
 - name: MEMORY_LIMIT
   value: '400Mi'
+- description: Path in the route to server requests from
+  name: ROUTE_PREFIX
+  required: true
+  value: "/api/mock-rhobs"
+  regex: '^\/api\/[a-zA-Z0-9-]+'  # Same regex as clowder without the final /

--- a/deploy/rhobs-mock.yaml
+++ b/deploy/rhobs-mock.yaml
@@ -14,11 +14,9 @@ objects:
           minReplicas: 1
           webServices:
             public:
-              enabled: false
-            private:
               enabled: true
-            metrics:
-              enabled: false
+              apiPaths:
+                - /api/mock-rhobs/
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             command: ["uvicorn", "rhobs:app", "--host", "0.0.0.0", "--port", "8000", "--log-config=logging.yaml"]


### PR DESCRIPTION
Add a public route for mock services.
Those services are actually externally accessible, so it make sense that their mocks are as well. In addition, it will help with configuring them from IQE tests.