### PR TITLE
Drop Service objects as we rely on clowder generated ones

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -49,21 +49,6 @@ objects:
               requests:
                 cpu: ${CPU_REQUEST}
                 memory: ${MEMORY_REQUEST}
-  - kind: Service
-    apiVersion: v1
-    metadata:
-      name: ccx-mock-ams
-      labels:
-        app: ccx-mock-ams
-    spec:
-      ports:
-        - name: web
-          port: 8000
-          protocol: TCP
-          targetPort: 8000
-      selector:
-        app: ccx-mock-ams
-      type: ClusterIP
 parameters:
 - description: Image name
   name: IMAGE

--- a/deploy/rhobs-mock.yaml
+++ b/deploy/rhobs-mock.yaml
@@ -49,21 +49,6 @@ objects:
               requests:
                 cpu: ${CPU_REQUEST}
                 memory: ${MEMORY_REQUEST}
-  - kind: Service
-    apiVersion: v1
-    metadata:
-      name: rhobs-mock-svc
-      labels:
-        app: rhobs-mock
-    spec:
-      ports:
-        - name: web
-          port: 8000
-          protocol: TCP
-          targetPort: 8000
-      selector:
-        app: rhobs-mock
-      type: ClusterIP
 parameters:
 - description: Image name
   name: IMAGE


### PR DESCRIPTION
See https://github.com/RedHatInsights/obsint-mocks/pull/153 (required)